### PR TITLE
Generic Stat Reporting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
     "no-unused-expressions": 1,
     "no-native-reassign": 1,
     "no-fallthrough": 1,
-    "handle-callback-err": 1,
     "camelcase": 1,
     "no-unused-vars": 1,
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,9 @@
   "globals": {
     "expect": true
   },
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
   "rules": {
     // Ignore Rules
     "strict": 0,
@@ -28,7 +31,7 @@
     // Errors
     "no-undef": 2,
     "no-dupe-keys": 2,
-    "no-empty-class": 2,
+    "no-empty-character-class": 2,
     "no-self-compare": 2,
     "valid-typeof": 2,
     "handle-callback-err": 2,
@@ -40,7 +43,7 @@
     // stylistic errors
     "new-cap": 2,
     "no-spaced-func": 2,
-    "no-space-before-semi": 2,
+    "semi-spacing": 2,
     "quotes": [1, "single"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ By default, all stats from artillery are reported. This includes any custom stat
 - `scenarioCounts.0`, `scenarioCounts.0` etc
 - `codes.200`, `codes.301` etc
 - `errors.ECONNREFUSED`, `errors.ETIMEDOUT` etc
+- `matches`
+- `concurrency`
+- `pendingRequests`
+
+Metrics will be added or removed based on what artillery decides to send.
+
+If a metric is null or cannot be resolved to a number, the default value of `0` is sent. You can change the default value in the configuration by passing in the property `default`. Example:
+
+`"default": 100000` - Metrics are sent with gauges so avoid [negative numbers](https://github.com/etsy/statsd/blob/master/docs/metric_types.md#gauges).
+
+Metrics can be skipped by passing in an additional configuration property `skipList`. Skip list values can look like the following:
+
+- `"skipList": "scenarioDuration"` - would skip all `scenarioDuration` metrics
+- `"skipList": "latency.max"` - would skip only the `latency.max` metric
+- `"skipList": "scenarioDuration, latency.max"` - a comma separated list can be used to pass in multiple values.
 
 ### Using with Librato
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Enable the plugin by adding it in your test script's `config.plugins` section:
 
 ### Published metrics
 
+By default, all stats from artillery are reported. This includes any custom stats you may have in place. As of `artillery@1.5.0-17`, the metrics you can expect to see are as follows.
+
 - `scenariosCreated`
 - `scenariosCompleted`
 - `requestsCompleted`
@@ -43,6 +45,15 @@ Enable the plugin by adding it in your test script's `config.plugins` section:
 - `latency.median`
 - `latency.p95`
 - `latency.p99`
+- `rps.count`
+- `rps.mean`
+- `scenarioDuration.min`
+- `scenarioDuration.max`
+- `scenarioDuration.median`
+- `scenarioDuration.p95`
+- `scenarioDuration.p99`
+- `scenarioCounts.0`, `scenarioCounts.0` etc
+- `codes.200`, `codes.301` etc
 - `errors.ECONNREFUSED`, `errors.ETIMEDOUT` etc
 
 ### Using with Librato

--- a/index.js
+++ b/index.js
@@ -4,76 +4,39 @@ var Lynx = require('lynx');
 var l = require('lodash');
 var debug = require('debug')('plugins:statsd');
 
-module.exports = StatsDPlugin;
-
-function StatsDPlugin(config, ee) {
+function StatsDPlugin(rawConfig, ee) {
   var self = this;
   self._report = [];
 
-  debug('StatsD Configuration: '+JSON.stringify(config.plugins.statsd));
+  var config = _reconcileConfigs(rawConfig);
+  debug('Resulting StatsD Configuration: '+JSON.stringify(config));
 
-  var host = config.plugins.statsd.host || 'localhost';
-  var port = config.plugins.statsd.port || 8125;
-  var globalPrefix = config.plugins.statsd.prefix || 'artillery';
-  var closingTimeout = config.plugins.statsd.timeout || 0;
-  var defaultValue = config.plugins.statsd.default || 0;
-  var skipList = ['timestamp', 'latencies']; //always skip these
-  // Add any values passed in by the user
-  if (l.isString(config.plugins.statsd.skipList)){
-    skipList = skipList.concat(config.plugins.statsd.skipList.split(','));
-  }
-  // This is used for testing the plugin interface
-  var enableUselessReporting = config.plugins.statsd.enableUselessReporting;
-
-  var metrics = new Lynx(host, port);
+  var metrics = new Lynx(config.host, config.port);
 
   ee.on('stats', function(statsObject) {
     var stats = statsObject.report()
     debug('Stats Report from Artillery: '+JSON.stringify(stats));
 
-    if (enableUselessReporting) {
+    if (config.enableUselessReporting) {
       self._report.push({ timestamp: stats.timestamp, value: 'test' });
     }
 
-    // Kick off gauging function using the globalPrefix
-    gaugeStats(globalPrefix, stats);
+    var flattenedStats = _flattenStats('',stats, config.skipList, config.defaultValue);
+    debug('Flattened Stats Report: '+JSON.stringify(flattenedStats));
 
-    // Parses the stats object and sub objects to gauge stats
-    function gaugeStats(name, value){
-      // Skip logic
-      if(l.contains(skipList, name.replace(globalPrefix+'.', ''))){
-        debug(name+' skipped');
-        return;
-      }
+    l.each(flattenedStats, function(value, name) {
+      debug('Reporting: '+name+'  '+value)
+      metrics.gauge(config.prefix+'.'+name, value || config.defaultValue);
+    });
 
-      // Recursively loop through objects with sub values such as latency/errors
-      if(l.size(value) > 0){
-        l.each(value, function(subValue, subName) {
-          gaugeStats(name+'.'+subName, subValue);
-        });
-      }
-      // Hey, it is an actual stat!
-      else if(l.isFinite(value)){
-        metrics.gauge(name, value);
-      }
-      // Artillery is sending null or NaN.
-      else if(l.isNaN(value) || l.isNull(value)){
-        metrics.gauge(name, defaultValue);
-      }
-      // Empty object such as 'errors' when there are not actually errors
-      else{
-        debug(name+' has nothing to report');
-        // no-op
-      }
-    }
   });
 
   ee.on('done', function(stats) {
     debug('done');
-    if (closingTimeout > 0) {
+    if (config.closingTimeout > 0) {
       setTimeout(function () {
         metrics.close();
-      }, closingTimeout);
+      }, config.closingTimeout);
     } else {
       metrics.close();
     }
@@ -81,6 +44,7 @@ function StatsDPlugin(config, ee) {
 
   return this;
 }
+
 
 StatsDPlugin.prototype.report = function report() {
   if (this._report.length === 0) {
@@ -93,3 +57,72 @@ StatsDPlugin.prototype.report = function report() {
     return this._report;
   }
 };
+
+// Parses the stats object and sub objects to gauge stats
+function _flattenStats(prefix, value, skipList, defaultValue){
+  var flattenedStats = {};
+  // Skip logic
+  if(l.contains(skipList, prefix)){
+    debug(prefix+' skipped');
+    return {};
+  }
+
+  // Recursively loop through objects with sub values such as latency/errors
+  if(l.size(value) > 0){
+    l.each(value, function(subValue, subName) {
+      var newPrefix = prefix;
+      if(newPrefix==='') {
+        newPrefix = subName;
+      }
+      else {
+        newPrefix += '.'+subName;
+      }
+      flattenedStats =  l.merge(flattenedStats, _flattenStats(newPrefix, subValue, skipList, defaultValue));
+    });
+  }
+  // Hey, it is an actual stat!
+  else if(l.isFinite(value)){
+    flattenedStats = l.merge(flattenedStats,{[prefix]: value});
+  }
+  // Artillery is sending null or NaN.
+  else if(l.isNaN(value) || l.isNull(value)){
+    flattenedStats = l.merge(flattenedStats,{[prefix]: defaultValue});
+  }
+  // Empty object such as 'errors' when there are not actually errors
+  else{
+    debug(prefix+' has nothing to report');
+    // no-op
+  }
+  return flattenedStats;
+}
+
+function _generateSkipList(input){
+  let skipList = ['timestamp', 'latencies']; //always skip these
+
+  // Add any values passed in by the user
+  if (l.isString(input)){
+    let inputWithoutSpaces = input.replace(/\s/g,'');
+    skipList = skipList.concat(inputWithoutSpaces.split(','));
+  }
+  return skipList;
+}
+
+function _reconcileConfigs(config){
+  return {
+     host: config.plugins.statsd.host || 'localhost',
+     port: config.plugins.statsd.port || 8125,
+     prefix: config.plugins.statsd.prefix || 'artillery',
+     closingTimeout: config.plugins.statsd.timeout || 0,
+     defaultValue: config.plugins.statsd.default || 0,
+     skipList: _generateSkipList(config.plugins.statsd.skipList),
+    // This is used for testing the plugin interface
+     enableUselessReporting: config.plugins.statsd.enableUselessReporting
+  }
+}
+
+module.exports = StatsDPlugin;
+
+// Exported for testing purposes...
+module.exports._generateSkipList = _generateSkipList;
+module.exports._flattenStats = _flattenStats;
+module.exports._reconcileConfigs = _reconcileConfigs;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Statsd output plugin for Artillery",
   "main": "index.js",
   "scripts": {
-    "test": "node test/index.js"
+    "test": "node test/index.js | tap-spec"
   },
   "keywords": [
     "statsd",
@@ -21,6 +21,8 @@
     "lynx": "^0.2.0"
   },
   "devDependencies": {
-    "eslint": "^3.9.0"
+    "eslint": "^3.9.0",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,16 @@
     "minigun"
   ],
   "author": "Hassy Veldstra <h@veldstra.org>",
+  "contributors": [
+    "Anthony DiPirro (https://github.com/adipirro)"
+  ],
   "license": "ISC",
   "dependencies": {
     "debug": "2.2.0",
     "lodash": "3.10.1",
     "lynx": "^0.2.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.9.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,91 @@
+var test = require('tape');
+var StatsDPlugin = require('../index')
+
+test('using advertised defaults', function (t) {
+  var reconciledConfigs = StatsDPlugin._reconcileConfigs({plugins: {statsd:{}}});
+
+  t.equal(reconciledConfigs.host, 'localhost', 'Host localhost');
+  t.equal(reconciledConfigs.port, 8125, 'Port 8125');
+  t.equal(reconciledConfigs.prefix, 'artillery', 'Prefix artillery');
+  t.equal(reconciledConfigs.closingTimeout, 0, 'Timeout 0');
+  t.equal(reconciledConfigs.defaultValue, 0, 'DefaultValue 0'); // needs to be zero since we use gauge https://github.com/etsy/statsd/blob/master/docs/metric_types.md
+  t.deepEqual(reconciledConfigs.skipList, ['timestamp', 'latencies'], 'Skipping timestamp and latencies');
+
+  t.end();
+});
+
+test('defaults are overridable', function (t) {
+  var config = {
+    plugins: {
+      statsd: {
+        host: 'somehost',
+        port: 8126,
+        prefix: 'someprefix',
+        timeout: 10,
+        default: 100000
+      }
+    }
+  };
+  var reconciledConfigs = StatsDPlugin._reconcileConfigs(config);
+
+  t.equal(reconciledConfigs.host, 'somehost', 'Host somehost');
+  t.equal(reconciledConfigs.port, 8126, 'Port 8126');
+  t.equal(reconciledConfigs.prefix, 'someprefix', 'Prefix someprefix');
+  t.equal(reconciledConfigs.closingTimeout, 10, 'Timeout 10');
+  t.equal(reconciledConfigs.defaultValue, 100000, 'DefaultValue 100000');
+
+  t.end();
+});
+
+test('skip list can handle user input', function (t) {
+  t.deepEqual(StatsDPlugin._generateSkipList('rps'), ['timestamp', 'latencies', 'rps'], 'Single Value');
+  t.deepEqual(StatsDPlugin._generateSkipList('rps,errors'), ['timestamp', 'latencies', 'rps', 'errors'], 'No Spaces');
+  t.deepEqual(StatsDPlugin._generateSkipList('rps, errors, codes'), ['timestamp', 'latencies', 'rps', 'errors', 'codes'], 'Spaces');
+  t.end();
+});
+
+test('flattening works', function (t) {
+  var commonSkipList = ['timestamp', 'latencies'];
+
+  var basic = {
+    basic: 500
+  };
+  var basicPlusSkipped = {
+    basic: 500,
+    timestamp: '2016-10-31T08:35:21.676Z',
+    latencies: [[1477902921336,'761465ff-220d-4924-b1c1-062868d3169b',428076699,301],[1477902921342,'e8fa92e9-50bf-4d67-bce9-f7bc8e3687ee',259315569,301]]
+  };
+  var nullProperty = {
+    scenariosCreated: null
+  }
+  var emptyProperty = {
+    errors: {}
+  }
+  var subProperties = {
+    customStats: {
+      so:{
+        value: 10,
+        many: {
+          value: 11,
+          properties: {
+            value: 12
+          }
+        }
+      }
+    }
+  };
+  var flatSubProperties = { 'customStats.so.many.properties.value': 12, 'customStats.so.many.value': 11, 'customStats.so.value': 10 };
+  var flatSubPropertiesSingleSkip = {'customStats.so.many.properties.value': 12, 'customStats.so.value': 10 };
+
+  t.deepEqual(StatsDPlugin._flattenStats('', basic, commonSkipList, 0), basic, 'Basic in, basic out');
+  t.deepEqual(StatsDPlugin._flattenStats('', basicPlusSkipped, commonSkipList, 0), basic, 'Basic plus skipped in, basic out');
+  t.deepEqual(StatsDPlugin._flattenStats('', basicPlusSkipped, commonSkipList.concat(['basic']), 0), {}, 'Basic plus skipped in, basic skipped, nothing out');
+  t.deepEqual(StatsDPlugin._flattenStats('', nullProperty, commonSkipList, 0), {scenariosCreated: 0}, 'Null in, default out');
+  t.deepEqual(StatsDPlugin._flattenStats('', emptyProperty, commonSkipList, 0), {}, 'Empty objects skipped');
+  t.deepEqual(StatsDPlugin._flattenStats('', subProperties, commonSkipList, 0), flatSubProperties, 'All the sub properties can come to the party');
+  t.deepEqual(StatsDPlugin._flattenStats('', subProperties, commonSkipList.concat(['customStats.so.many.value']), 0), flatSubPropertiesSingleSkip, 'Sub properties can be skipped');
+  t.deepEqual(StatsDPlugin._flattenStats('', subProperties, commonSkipList.concat(['customStats.so']), 0), {}, 'Skipping a parent property skips all children');
+
+
+  t.end();
+});


### PR DESCRIPTION
As mentioned in my last pull request, I think moving to a generic approach for reporting is a good idea. Also, while not a complete fix for shoreditch-ops/artillery#193, it does help with some of the pain. 

I went ahead and implemented what I was thinking of because I was bored :) Through in some tests for kicks as well. They are hopefully thorough and are easy to read, making your job a little easier.

**Basic Flow**

1. "Flatten" the stats object. Unwanted values are skipped, default values are set, and we get a single object with reportable metrics. 

  ```
  {timestamp: '9999-99-9', single: 5, nested:{value1: null, value2: 10}}
  //becomes
  {'single': 5, 'nested.value1': 0, 'nested.value2': 10}
  ```

2. Loop through this new flattened object and gauge the statistics, prepending the configured prefix.

