### PR TITLE
Added tags support for influxDB reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ Enable the plugin by adding it in your test script's `config.plugins` section:
       "statsd": {
         "host": "localhost",
         "port": 8125,
-        "prefix": "artillery"
+        "prefix": "artillery",
+        "influx_tags": { // optional: reports to influxDB will be tagged with those tags
+            "tag1": "value1",
+            "tag2": "value2",
+        }
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -26,7 +26,11 @@ function StatsDPlugin(rawConfig, ee) {
 
     l.each(flattenedStats, function(value, name) {
       debug('Reporting: '+name+'  '+value)
-      metrics.gauge(config.prefix+'.'+name, value || config.defaultValue);
+      var tagString = _.reduce(config.influx_tags, (result, tagValue, tagName) => {
+          result += ',' + tagName + "=" + tagValue;
+          return result;
+      }, "");
+      metrics.gauge(config.prefix+'.'+name + tagString, value || config.defaultValue);
     });
 
   });


### PR DESCRIPTION
This PR should add the option to tag reports to influxDB. No need to change any existing script, as this only adds an optional capability.
Also updated the documentation to mention the new option